### PR TITLE
Fix Homepage layout in chrome and add dev README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,6 @@ These instructions will get you a copy of the Hyperfoil.io website up and runnin
 **For more regarding the use of Jekyll, please refer to the [Jekyll Step by Step Tutorial](https://jekyllrb.com/docs/step-by-step/01-setup/).**
 
 
-## Contributing
-
-Please read [CONTRIBUTING.md](https://github.com/quarkusio/quarkusio.github.io/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
-
-**Important:** the guides are maintained in the main Quarkus repository and pull requests should be submitted there:
-https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc.
-
 ## License
 
 This website is licensed under the [Creative Commons Attribution 3.0](https://creativecommons.org/licenses/by/3.0/).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Hyperfoil.io Website Based on Jekyll
+
+## Getting Started
+
+These instructions will get you a copy of the Hyperfoil.io website up and running on your local machine for development and testing purposes.
+
+### Installation
+[Jekyll static site generator docs](https://jekyllrb.com/docs/).
+
+1. Install a full [Ruby development environment](https://jekyllrb.com/docs/installation/)
+2. Install [bundler](https://jekyllrb.com/docs/ruby-101/#bundler)  [gems](https://jekyllrb.com/docs/ruby-101/#gems) 
+  
+        gem install bundler
+
+3. Fork the [project repository](https://github.com/Hyperfoil/hyperfoil.github.io), then clone your fork.
+  
+        git clone git@github.com:YOUR_USER_NAME/hyperfoil.github.io.git
+
+4. Change into the project directory:
+  
+        cd hyperfoil.github.io
+
+5. Use bundler to fetch all required gems in their respective versions
+
+        bundle install
+
+6. Build the site and make it available on a local server
+  
+        bundle exec jekyll serve
+        
+7. Now browse to http://localhost:4000
+
+> If you encounter any unexpected errors during the above, please refer to the [troubleshooting](https://jekyllrb.com/docs/troubleshooting/#configuration-problems) page or the [requirements](https://jekyllrb.com/docs/installation/#requirements) page, as you might be missing development headers or other prerequisites.
+
+**For more regarding the use of Jekyll, please refer to the [Jekyll Step by Step Tutorial](https://jekyllrb.com/docs/step-by-step/01-setup/).**
+
+
+## Contributing
+
+Please read [CONTRIBUTING.md](https://github.com/quarkusio/quarkusio.github.io/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+
+**Important:** the guides are maintained in the main Quarkus repository and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc.
+
+## License
+
+This website is licensed under the [Creative Commons Attribution 3.0](https://creativecommons.org/licenses/by/3.0/).

--- a/_posts/2021-02-09-hf-beginner-guide-2.md
+++ b/_posts/2021-02-09-hf-beginner-guide-2.md
@@ -5,7 +5,7 @@ excerpt: In this post we will focus on processing of responses and user workflow
 
 > This article is intended to be published on other sites, too - therefore it contains introduction to concepts this blog’s readers are probably familiar with.
 
-In the [previous part]({{ '/2021/01/25/hf-beginner-guide-1.html' | absolute_url }}) we've deployed our demo application (Vehicle Market) and exercised some basic requests against that. In this post we will focus on processing of responses and user workflow through the site.
+In the [previous part]({{ '/2021/01/25/hf-beginner-guide-1.html' | absolute_url }}) we've deployed our demo application (Vehicle Market) and exercised some basic requests against that. In this post we will focus on processing responses and user workflow through the site.
 
 ## Processing responses
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -91,11 +91,10 @@ a { color: var(--theme-color-base); }
 
 #features { clear: both; display: table; }
 
-.feature { width: 20%; padding: 20px; float: left; }
-.feature div { text-align: center; }
-.feature_icon_box { height: 110px; }
+.feature { text-align: center; width: 20%; padding: 20px; float: left; }
+.feature_icon_box { height: 110px;}
 .feature_icon_box:hover { transform: scale(1.05); }
-.feature img { width: 100px; border: 0px; vertical-align: bottom; display: table-cell; }
+.feature img { width: 100px; border: 0px; }
 
 #blogcontainer {
 	display: flex;

--- a/index.md
+++ b/index.md
@@ -20,31 +20,25 @@ main_wrap_full_height: false
         Drive the load from many nodes.
     </div>
     <div class="feature">
-        <div>
-            <div class="feature_icon_box">
-                <!-- Fix me if you know CSS -->
-                <img style="position: relative; top: 15px; left: 7px;" src="assets/images/graph_arrow_spike.png" alt="Accurate">
-            </div>
-            <h4>Accurate</h4>
+        <div class="feature_icon_box">
+            <!-- Fix me if you know CSS -->
+            <img style="position: relative; top: 15px; left: 7px;" src="assets/images/graph_arrow_spike.png" alt="Accurate">
         </div>
-        All operations are async to avoid the <a href="https://www.azul.com/files/HowNotToMeasureLatency_LLSummit_NYC_12Nov2013.pdf">coordinated-omission fallacy</a>.
+        <h4>Accurate</h4>
+        <p>All operations are async to avoid the <a href="https://www.azul.com/files/HowNotToMeasureLatency_LLSummit_NYC_12Nov2013.pdf">coordinated-omission fallacy</a>.</p>
     </div>
     <div class="feature">
-        <div>
-            <div class="feature_icon_box">
-                <img src="assets/images/puzzle_complete.png" alt="Versatile">
-            </div>
-            <h4>Versatile</h4>
+        <div class="feature_icon_box">
+            <img src="assets/images/puzzle_complete.png" alt="Versatile">
         </div>
-        You can express complex scenarios either in YAML or through pluggable steps.
+        <h4>Versatile</h4>
+        <p>You can express complex scenarios either in YAML or through pluggable steps.</p>
     </div>
     <div class="feature">
-        <div>
-            <div class="feature_icon_box">
-                <img src="assets/images/recycle_symbol.png" alt="Low-allocation">
-            </div>
-            <h4>Low-allocation</h4>
+        <div class="feature_icon_box">
+            <img src="assets/images/recycle_symbol.png" alt="Low-allocation">
         </div>
-        Internally we try to allocate as little as possible on the critical code paths to not let garbage-collector disturb the operations.
+        <h4>Low-allocation</h4>
+        <p>Internally we try to allocate as little as possible on the critical code paths to not let garbage-collector disturb the operations.</p>
     </div>
 </div>


### PR DESCRIPTION
This PR;

- Corrects the "Feature" layout in Chrome, it also centrally aligns "Feature" text in FF.
- Adds a README.md that describes how to set up an environment for running Jekyll locally.