### PR TITLE
Fix JSON schema redirection

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 ---
-redirectFrom: /schema
+redirect_from: /schema
 ---
 {
   "$schema" : "http://json-schema.org/draft-07/schema",


### PR DESCRIPTION
Fixes https://github.com/Hyperfoil/Hyperfoil/issues/341

Fix the `schema.json` redirection, with this change `https://hyperfoil.io/schema` will redirect to `https://hyperfoil.io/schema.json`.

This seems to fix the redirection problem, but (once fixed) using:
```json
"yaml.schemas" : {
    "https://hyperfoil.io/schema" : "/*.hf.yaml"
},
```
looks not properly working as yaml validator does not follow redirects, at least that was my impression.
I found an old [issue](https://github.com/redhat-developer/vscode-yaml/issues/586) mentioning that problem but it should have been fixed based on the comment. It will need further investigation.

BTW even with this fix I'd still suggest to keep using `"https://hyperfoil.io/schema.json" : "/*.hf.yaml"`.