### PR TITLE
Add useHttpCache doc

### DIFF
--- a/userguide/benchmark/http.md
+++ b/userguide/benchmark/http.md
@@ -39,6 +39,7 @@ HTTP configuration has these properties:
 | rawBytesHandlers  | true    | Enable or disable using handlers that process HTTP response raw bytes. |
 | [keyManager](#keymanager-configuration) |         | TLS key manager for setting up client certificates. |
 | [trustManager](#trustmanager-configuration) |         | TLS trust manager for setting up server certificates. |
+| useHttpCache      | true    | Make use of HTTP cache on client-side. If multiple authorities are involved, disable the HTTP cache for all of them to achieve the desired outcomes. |
 
 ## Shared connections
 


### PR DESCRIPTION
Add documentation for the newly introduced `useHttpCache` field https://github.com/Hyperfoil/Hyperfoil/pull/375

**NOTE**: This should be merged only once a new release is rolled out including the new feature.