### PR TITLE
Add automated gh pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -1,0 +1,66 @@
+name: Build and deploy Hyperfoil website
+
+on:
+  workflow_dispatch:
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build website
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      HUGO_VERSION: 0.119.0
+      NODE_VERSION: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'Hyperfoil/Hyperfoil'
+          ref: '0.26.x'
+      
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install npm packages
+        working-directory: ./docs/site
+        run: npm install --save-dev autoprefixer postcss-cli postcss
+        
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        working-directory: ./docs/site
+        run: |
+          hugo --minify --baseURL https://hyperfoil.io
+    
+      - name: Debug generated website
+        working-directory: ./docs/site
+        run: ls -la public/
+    
+      - name: Deploy website
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/site/public


### PR DESCRIPTION
Add new workflow to automatically deploy Hyperfoil website taking content from Hyperfoil repo.

TODOs:
- [x] Create empty `gh-pages` branch
- [ ] From settings, change the gh-pages branch from `master` to `gh-pages`

Prerequisities:
- [x] Merged https://github.com/Hyperfoil/Hyperfoil/pull/379